### PR TITLE
draft: feat: outline shaders

### DIFF
--- a/shader/outline_pass.fs
+++ b/shader/outline_pass.fs
@@ -1,0 +1,42 @@
+#version 330
+
+in vec2 fragTexCoord;
+out vec4 fragColor;
+
+uniform sampler2D texture0;
+uniform vec2 textureSize;
+uniform float outlineThickness;
+
+void main() {
+    vec2 uv = fragTexCoord;
+    vec2 texel = 1.0 / textureSize;
+
+    vec4 center = texture(texture0, uv);
+    if (center.a > 0.001) {
+        fragColor = vec4(center.rgb, 1.0);
+        return;
+    }
+
+    float accum = 0.0;
+    vec2 offsets[8] = vec2[](
+        vec2(-1.0,  0.0),
+        vec2( 1.0,  0.0),
+        vec2( 0.0, -1.0),
+        vec2( 0.0,  1.0),
+        vec2(-1.0, -1.0),
+        vec2( 1.0, -1.0),
+        vec2(-1.0,  1.0),
+        vec2( 1.0,  1.0)
+    );
+
+    for (int i = 0; i < 8; ++i) {
+        vec2 sampleUv = uv + offsets[i] * texel * outlineThickness;
+        accum += texture(texture0, sampleUv).a;
+    }
+
+    if (accum <= 0.001) {
+        discard;
+    }
+
+    fragColor = vec4(0.05, 0.05, 0.05, 1.0);
+}

--- a/src/YataiDON.cpp
+++ b/src/YataiDON.cpp
@@ -217,7 +217,7 @@ int main(int argc, char* argv[]) {
     spdlog::info("Starting YataiDON");
     set_working_directory_to_executable();
     global_data.config = new Config(get_config());
-    unsigned int flags = ray::FLAG_MSAA_4X_HINT | ray::FLAG_WINDOW_RESIZABLE;
+    unsigned int flags = ray::FLAG_WINDOW_RESIZABLE;
     if (global_data.config->video.vsync) {
         flags |= ray::FLAG_VSYNC_HINT;
         spdlog::info("VSync enabled");

--- a/src/objects/global/chara_3d.cpp
+++ b/src/objects/global/chara_3d.cpp
@@ -120,7 +120,7 @@ Chara3D::Chara3D(std::string& model_name, bool mirror) {
 
     outline_shader = ray::LoadShader("shader/outline.vs", "shader/outline.fs");
     int thickness_loc = ray::GetShaderLocation(outline_shader, "outlineThickness");
-    float thickness = 0.01f;
+    float thickness = 0.0035f;
     ray::SetShaderValue(outline_shader, thickness_loc, &thickness, ray::SHADER_UNIFORM_FLOAT);
 
     this->mirror = mirror;
@@ -343,6 +343,29 @@ void Chara3D::update(double current_ms) {
             int loop_frames = anims[ai].keyframeCount - 1;
             anim_frame = (anim_frame + 1) % loop_frames;
             ray::UpdateModelAnimation(cos_model, anims[ai], anim_frame);
+            // Push updated vertex/normal/uv buffers to GPU after animation update.
+            for (int m = 0; m < cos_model.meshCount; m++) {
+                auto& mesh = cos_model.meshes[m];
+                if (mesh.vertexCount <= 0) continue;
+                // Vertex positions (location 0)
+                if (mesh.animVertices != nullptr)
+                    ray::UpdateMeshBuffer(mesh, 0, mesh.animVertices, mesh.vertexCount * 3 * sizeof(float), 0);
+                else if (mesh.vertices != nullptr)
+                    ray::UpdateMeshBuffer(mesh, 0, mesh.vertices, mesh.vertexCount * 3 * sizeof(float), 0);
+
+                // Normals (location 2)
+                if (mesh.animNormals != nullptr)
+                    ray::UpdateMeshBuffer(mesh, 2, mesh.animNormals, mesh.vertexCount * 3 * sizeof(float), 0);
+                else if (mesh.normals != nullptr)
+                    ray::UpdateMeshBuffer(mesh, 2, mesh.normals, mesh.vertexCount * 3 * sizeof(float), 0);
+
+                // UVs (primary texcoords: location 1)
+                if (mesh.texcoords != nullptr)
+                    ray::UpdateMeshBuffer(mesh, 1, mesh.texcoords, mesh.vertexCount * 2 * sizeof(float), 0);
+                // secondary texcoords (location 5)
+                if (mesh.texcoords2 != nullptr)
+                    ray::UpdateMeshBuffer(mesh, 5, mesh.texcoords2, mesh.vertexCount * 2 * sizeof(float), 0);
+            }
             last_frame_ms = current_ms;
 
             if (!is_looping && anim_frame == loop_frames - 1) {

--- a/src/objects/global/chara_3d.cpp
+++ b/src/objects/global/chara_3d.cpp
@@ -118,6 +118,12 @@ Chara3D::Chara3D(std::string& model_name, bool mirror) {
     fxaa_shader   = ray::LoadShader("shader/dummy.vs", "shader/fxaa.fs");
     fxaa_size_loc = ray::GetShaderLocation(fxaa_shader, "textureSize");
 
+    outline_pass_shader = ray::LoadShader("shader/dummy.vs", "shader/outline_pass.fs");
+    outline_pass_size_loc = ray::GetShaderLocation(outline_pass_shader, "textureSize");
+    outline_pass_thickness_loc = ray::GetShaderLocation(outline_pass_shader, "outlineThickness");
+    float outline_thickness = 3.0f;
+    ray::SetShaderValue(outline_pass_shader, outline_pass_thickness_loc, &outline_thickness, ray::SHADER_UNIFORM_FLOAT);
+
     outline_shader = ray::LoadShader("shader/outline.vs", "shader/outline.fs");
     int thickness_loc = ray::GetShaderLocation(outline_shader, "outlineThickness");
     float thickness = 0.0035f;
@@ -174,7 +180,9 @@ Chara3D::~Chara3D() {
     ray::UnloadModelAnimations(anims, anim_count);
     ray::UnloadModel(cos_model);
     ray::UnloadShader(fxaa_shader);
+    ray::UnloadShader(outline_pass_shader);
     if (fxaa_target.id != 0) ray::UnloadRenderTexture(fxaa_target);
+    if (scene_target.id != 0) ray::UnloadRenderTexture(scene_target);
     ray::UnloadShader(outline_shader);
     for (auto& tex : face_textures)
         ray::UnloadTexture(tex);
@@ -417,6 +425,15 @@ void Chara3D::draw(float x, float y) {
     int rw = ray::GetRenderWidth();
     int rh = ray::GetRenderHeight();
 
+    if (scene_target.id == 0 || scene_target_w != rw || scene_target_h != rh) {
+        if (scene_target.id != 0) ray::UnloadRenderTexture(scene_target);
+        scene_target   = ray::LoadRenderTexture(rw, rh);
+        scene_target_w = rw;
+        scene_target_h = rh;
+        float ts[2] = {(float)rw, (float)rh};
+        ray::SetShaderValue(outline_pass_shader, outline_pass_size_loc, ts, ray::SHADER_UNIFORM_VEC2);
+    }
+
     if (fxaa_target.id == 0 || fxaa_target_w != rw || fxaa_target_h != rh) {
         if (fxaa_target.id != 0) ray::UnloadRenderTexture(fxaa_target);
         fxaa_target   = ray::LoadRenderTexture(rw, rh);
@@ -432,7 +449,7 @@ void Chara3D::draw(float x, float y) {
     ray::EndMode2D();
     ray::EndBlendMode();
 
-    ray::BeginTextureMode(fxaa_target);
+    ray::BeginTextureMode(scene_target);
     ray::ClearBackground(ray::BLANK);
     ray::BeginBlendMode(ray::BLEND_CUSTOM_SEPARATE);
     ray::BeginMode3D(cam3d);
@@ -440,6 +457,15 @@ void Chara3D::draw(float x, float y) {
     draw_3d(x, y);
     ray::EndMode3D();
     ray::EndBlendMode();
+    ray::EndTextureMode();
+
+    ray::BeginTextureMode(fxaa_target);
+    ray::ClearBackground(ray::BLANK);
+    ray::BeginShaderMode(outline_pass_shader);
+    ray::DrawTextureRec(scene_target.texture,
+        {0, 0, (float)rw, -(float)rh},
+        {0, 0}, ray::WHITE);
+    ray::EndShaderMode();
     ray::EndTextureMode();
 
     ray::BeginShaderMode(fxaa_shader);

--- a/src/objects/global/chara_3d.h
+++ b/src/objects/global/chara_3d.h
@@ -88,8 +88,8 @@ private:
     double last_frame_ms = 0;
 
     float scale = 650.0f;
-    float rot_x = 180.0f;
-    float rot_y = 20.0f;
+    float rot_x = 181.25f;
+    float rot_y = 27.5f;
     float rot_z = 0.0f;
 
     AnimIndex prev_anim_idx = AnimIndex::DON_BALLOON_FAILURE;
@@ -101,7 +101,14 @@ private:
     int fxaa_target_w = 0;
     int fxaa_target_h = 0;
 
+    ray::RenderTexture2D scene_target = {};
+    int scene_target_w = 0;
+    int scene_target_h = 0;
+
     ray::Shader outline_shader;
+    ray::Shader outline_pass_shader;
+    int outline_pass_size_loc = -1;
+    int outline_pass_thickness_loc = -1;
 
     void set_texture(fs::path& texture_path, int material_index);
     void load_face_textures(fs::path& face_dir);


### PR DESCRIPTION
See the following message on Discord for preview images:
https://discord.com/channels/722513061419810946/1468772072262992022/1511626752185733161

# Implemented
- In `Chara3D::update`, code has been added to update vertex normals after applying model animations
  - This is needed to extrude the mesh to the correct direction for the outline
- Adjusted inverse hull thickness to better match the official look
- Added a second pass that draws the 2D outline
- Adjusted the character rotation values to better match the official look
- Disabled MSAA flag (as far as I can tell, there is no visible differences)

# Issues
- FXAA pass is not currently working for reasons unknown
- 3D inverse hull leaves some weird artifacts near edges

Currently I don't have any ideas on how to fix these issues, so you may merge the current changes to master if they're good enough for now