### PR TITLE
add follow_directory_symlink option in get_song_files

### DIFF
--- a/src/libs/filesystem.cpp
+++ b/src/libs/filesystem.cpp
@@ -90,7 +90,7 @@ std::vector<fs::path> get_song_files(std::vector<fs::path> root_path) {
         try {
             std::vector<fs::path> osz_files;
             for (const auto& entry : fs::recursive_directory_iterator(
-                     path, fs::directory_options::skip_permission_denied)) {
+                     path, fs::directory_options::skip_permission_denied | fs::directory_options::follow_directory_symlink)) {
                 if (entry.path().extension() == ".osz")
                     osz_files.push_back(entry.path());
             }
@@ -103,7 +103,7 @@ std::vector<fs::path> get_song_files(std::vector<fs::path> root_path) {
         // Second pass: collect .tja and .osu files
         try {
             for (const auto& entry : std::filesystem::recursive_directory_iterator(
-                     path, std::filesystem::directory_options::skip_permission_denied)) {
+                     path, std::filesystem::directory_options::skip_permission_denied | std::filesystem::directory_options::follow_directory_symlink)) {
                 auto ext = entry.path().extension();
                 if (ext == ".tja" || ext == ".osu" || ext == ".bin") {
                     songs.push_back(entry.path());


### PR DESCRIPTION
YataiDON version of Yonokid/PyTaiko#144. Adds `follow_directory_symlink` option to the `get_song_files` function when getting the list of song paths when subfolders inside the songs folder are symlinked. Otherwise, the songs aren't added to the songs table in `scores.db`.

Example genre folders:
```
YataiDON/Songs/
├── 01 Pop -> /home/somepin/tjas/01 Pop
├── 02 Anime -> /home/somepin/tjas/02 Anime
...
├── 11 Dan Dojo
├── 12 Downloaded
├── 13 Recommended
├── 14 Favorites
├── 15 Recently Played
├── 16 Difficulty Sort
└── 17 New
```